### PR TITLE
feat: add office filtering and past meetings

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
     * { box-sizing: border-box; }
     body { margin: 0; font-family: var(--ff); background: var(--bg); color: #333; padding: var(--pad); }
     h2 { margin: 0 0 16px; color: var(--primary); text-align: center; }
+    h3 { margin: 32px 0 16px; color: var(--primary); text-align: center; }
     form { max-width: 600px; margin: 0 auto 24px; background: #fff; border-radius: var(--radius); padding: var(--pad); box-shadow: 0 4px 12px rgba(0,0,0,.05); }
     .row-2 { display: grid; grid-template-columns: repeat(2, 1fr); gap: 12px 16px; margin-bottom: 16px; }
     .field { display: flex; flex-direction: column; }
@@ -113,9 +114,17 @@
   </form>
   <table id="bookingTable">
     <thead>
-      <tr><th>辦公室</th><th>會議室</th><th>日期</th><th>開始</th><th>結束</th><th>主題</th><th>預約人</th></tr>
+      <tr><th>辦公室</th><th>會議室</th><th>日期</th><th>開始</th><th>結束</th><th>主題</th><th>預約人</th><th>操作</th></tr>
     </thead>
-    <tbody><tr><td colspan="7" class="muted">尚無預約</td></tr></tbody>
+    <tbody><tr><td colspan="8" class="muted">尚無預約</td></tr></tbody>
+  </table>
+
+  <h3>過往會議</h3>
+  <table id="pastTable">
+    <thead>
+      <tr><th>辦公室</th><th>會議室</th><th>日期</th><th>開始</th><th>結束</th><th>主題</th><th>預約人</th><th>操作</th></tr>
+    </thead>
+    <tbody><tr><td colspan="8" class="muted">無過往會議</td></tr></tbody>
   </table>
 
   <!-- 日曆覆蓋層 -->
@@ -147,13 +156,29 @@
       b.office===nb.office && b.room===nb.room && b.date===nb.date &&
       !(nb.endTime<=b.startTime||nb.startTime>=b.endTime)
     ); }
-    function renderTable(){ const tbody=document.querySelector('#bookingTable tbody'), bs=loadBookings();
-      if(!bs.length){ tbody.innerHTML='<tr><td colspan="7" class="muted">尚無預約</td></tr>'; return; }
-      bs.sort((a,b)=>a.date.localeCompare(b.date)||a.startTime.localeCompare(b.startTime));
-      tbody.innerHTML=bs.map(b=>`<tr>
-        <td>${b.office==='huashan'?'華山辦公室':'三重辦公室'}</td>
-        <td>${b.room}</td><td>${b.date}</td><td>${b.startTime}</td><td>${b.endTime}</td><td>${b.subject}</td><td>${b.organizer}</td>
-      </tr>`).join(''); }
+    function renderTables(){ const tbody=document.querySelector('#bookingTable tbody'), pastTbody=document.querySelector('#pastTable tbody'), bs=loadBookings();
+      const office=document.getElementById('office').value;
+      const today=new Date().toISOString().slice(0,10);
+      const entries=bs.map((b,i)=>({b,i})).filter(e=>e.b.office===office);
+      const upcoming=entries.filter(e=>e.b.date>=today);
+      const past=entries.filter(e=>e.b.date<today);
+      if(!upcoming.length){ tbody.innerHTML='<tr><td colspan="8" class="muted">尚無預約</td></tr>'; } else {
+        upcoming.sort((a,b)=>a.b.date.localeCompare(b.b.date)||a.b.startTime.localeCompare(b.b.startTime));
+        tbody.innerHTML=upcoming.map(e=>`<tr>
+          <td>${e.b.office==='huashan'?'華山辦公室':'三重辦公室'}</td>
+          <td>${e.b.room}</td><td>${e.b.date}</td><td>${e.b.startTime}</td><td>${e.b.endTime}</td><td>${e.b.subject}</td><td>${e.b.organizer}</td>
+          <td><button class="del-btn" data-idx="${e.i}">刪除</button></td>
+        </tr>`).join(''); }
+      if(!past.length){ pastTbody.innerHTML='<tr><td colspan="8" class="muted">無過往會議</td></tr>'; } else {
+        past.sort((a,b)=>a.b.date.localeCompare(b.b.date)||a.b.startTime.localeCompare(b.b.startTime));
+        pastTbody.innerHTML=past.map(e=>`<tr>
+          <td>${e.b.office==='huashan'?'華山辦公室':'三重辦公室'}</td>
+          <td>${e.b.room}</td><td>${e.b.date}</td><td>${e.b.startTime}</td><td>${e.b.endTime}</td><td>${e.b.subject}</td><td>${e.b.organizer}</td>
+          <td><button class="del-btn" data-idx="${e.i}">刪除</button></td>
+        </tr>`).join(''); }
+      document.querySelectorAll('.del-btn').forEach(btn=>btn.addEventListener('click',()=>{
+        const idx=+btn.dataset.idx; const list=loadBookings(); list.splice(idx,1); saveBookings(list); renderTables();
+      })); }
 
     // 表單事件
     const form=document.getElementById('bookingForm'), err=document.getElementById('errorMsg');
@@ -166,9 +191,14 @@
       if(end<=start){ err.textContent='結束時間需晚於開始時間。'; return; }
       const nb={office,room,date,startTime:start,endTime:end,subject,organizer:org}, bs=loadBookings();
       if(hasConflict(bs,nb)){ err.textContent='此時段已被預約，請選其他時間或會議室。'; return; }
-      bs.push(nb); saveBookings(bs); renderTable(); form.reset();
+      bs.push(nb); saveBookings(bs);
+      const keepOffice=form.office.value;
+      renderTables();
+      form.reset();
+      form.office.value=keepOffice;
     });
-    document.getElementById('resetBtn').addEventListener('click',()=>{ form.reset(); err.textContent=''; });
+    document.getElementById('resetBtn').addEventListener('click',()=>{ form.reset(); err.textContent=''; renderTables(); });
+    document.getElementById('office').addEventListener('change',renderTables);
 
     // 日期／時間選擇器共用
     const calOverlay=document.getElementById('calOverlay'), grid=document.getElementById('calGrid'), titleEl=document.getElementById('calTitle'), prevBtn=document.getElementById('calPrev'), nextBtn=document.getElementById('calNext');
@@ -212,7 +242,7 @@
       const d=new Date(); d.setHours(hh); d.setMinutes(mm+mins);
       document.getElementById('endTime').value=`${String(d.getHours()).padStart(2,'0')}:${String(d.getMinutes()).padStart(2,'0')}`;
     }));
-    renderTable();
+    renderTables();
   })();
   </script>
 </body>


### PR DESCRIPTION
## Summary
- filter and split bookings by office selection
- allow deleting meetings
- show past meetings separately from upcoming

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_b_689168707afc8320a07b57a6d8035798