### PR TITLE
feat: add office filtering and past meetings

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
     * { box-sizing: border-box; }
     body { margin: 0; font-family: var(--ff); background: var(--bg); color: #333; padding: var(--pad); }
     h2 { margin: 0 0 16px; color: var(--primary); text-align: center; }
+    h3 { margin: 32px 0 16px; color: var(--primary); text-align: center; }
     form { max-width: 600px; margin: 0 auto 24px; background: #fff; border-radius: var(--radius); padding: var(--pad); box-shadow: 0 4px 12px rgba(0,0,0,.05); }
     .row-2 { display: grid; grid-template-columns: repeat(2, 1fr); gap: 12px 16px; margin-bottom: 16px; }
     .field { display: flex; flex-direction: column; }
@@ -98,6 +99,8 @@
           <button type="button" class="duration-btn" data-minutes="30">30分鐘</button>
           <button type="button" class="duration-btn" data-minutes="45">45分鐘</button>
           <button type="button" class="duration-btn" data-minutes="60">60分鐘</button>
+          <button type="button" class="duration-btn" data-minutes="90">90分鐘</button>
+          <button type="button" class="duration-btn" data-minutes="120">120分鐘</button>
         </div>
       </div>
       <div class="field">
@@ -113,9 +116,17 @@
   </form>
   <table id="bookingTable">
     <thead>
-      <tr><th>辦公室</th><th>會議室</th><th>日期</th><th>開始</th><th>結束</th><th>主題</th><th>預約人</th></tr>
+      <tr><th>辦公室</th><th>會議室</th><th>日期</th><th>開始</th><th>結束</th><th>主題</th><th>預約人</th><th>操作</th></tr>
     </thead>
-    <tbody><tr><td colspan="7" class="muted">尚無預約</td></tr></tbody>
+    <tbody><tr><td colspan="8" class="muted">尚無預約</td></tr></tbody>
+  </table>
+
+  <h3>過往會議</h3>
+  <table id="pastTable">
+    <thead>
+      <tr><th>辦公室</th><th>會議室</th><th>日期</th><th>開始</th><th>結束</th><th>主題</th><th>預約人</th><th>操作</th></tr>
+    </thead>
+    <tbody><tr><td colspan="8" class="muted">無過往會議</td></tr></tbody>
   </table>
 
   <!-- 日曆覆蓋層 -->
@@ -143,17 +154,38 @@
     // 資料存取
     function loadBookings(){ const d=localStorage.getItem('meetings'); return d?JSON.parse(d):[]; }
     function saveBookings(bs){ localStorage.setItem('meetings',JSON.stringify(bs)); }
+    function loadPast(){ const d=localStorage.getItem('pastMeetings'); return d?JSON.parse(d):[]; }
+    function savePast(bs){ localStorage.setItem('pastMeetings',JSON.stringify(bs)); }
     function hasConflict(bs, nb){ return bs.some(b=>
       b.office===nb.office && b.room===nb.room && b.date===nb.date &&
       !(nb.endTime<=b.startTime||nb.startTime>=b.endTime)
     ); }
-    function renderTable(){ const tbody=document.querySelector('#bookingTable tbody'), bs=loadBookings();
-      if(!bs.length){ tbody.innerHTML='<tr><td colspan="7" class="muted">尚無預約</td></tr>'; return; }
-      bs.sort((a,b)=>a.date.localeCompare(b.date)||a.startTime.localeCompare(b.startTime));
-      tbody.innerHTML=bs.map(b=>`<tr>
-        <td>${b.office==='huashan'?'華山辦公室':'三重辦公室'}</td>
-        <td>${b.room}</td><td>${b.date}</td><td>${b.startTime}</td><td>${b.endTime}</td><td>${b.subject}</td><td>${b.organizer}</td>
-      </tr>`).join(''); }
+    function archivePast(){ const today=new Date().toISOString().slice(0,10); const bs=loadBookings(); if(!bs.length) return; const upcoming=[], past=loadPast(); bs.forEach(b=>{ (b.date<today?past:upcoming).push(b); }); if(upcoming.length!==bs.length){ saveBookings(upcoming); savePast(past); } }
+    function renderTables(){ archivePast(); const tbody=document.querySelector('#bookingTable tbody'), pastTbody=document.querySelector('#pastTable tbody'), bs=loadBookings(), pastBs=loadPast();
+      const office=document.getElementById('office').value;
+      const upcoming=bs.map((b,i)=>({b,i})).filter(e=>e.b.office===office);
+      const past=pastBs.map((b,i)=>({b,i})).filter(e=>e.b.office===office);
+      if(!upcoming.length){ tbody.innerHTML='<tr><td colspan="8" class="muted">尚無預約</td></tr>'; } else {
+        upcoming.sort((a,b)=>a.b.date.localeCompare(b.b.date)||a.b.startTime.localeCompare(b.b.startTime));
+        tbody.innerHTML=upcoming.map(e=>`<tr>
+          <td>${e.b.office==='huashan'?'華山辦公室':'三重辦公室'}</td>
+          <td>${e.b.room}</td><td>${e.b.date}</td><td>${e.b.startTime}</td><td>${e.b.endTime}</td><td>${e.b.subject}</td><td>${e.b.organizer}</td>
+          <td><button class="del-btn" data-type="upcoming" data-idx="${e.i}">刪除</button></td>
+        </tr>`).join(''); }
+      if(!past.length){ pastTbody.innerHTML='<tr><td colspan="8" class="muted">無過往會議</td></tr>'; } else {
+        past.sort((a,b)=>a.b.date.localeCompare(b.b.date)||a.b.startTime.localeCompare(b.b.startTime));
+        pastTbody.innerHTML=past.map(e=>`<tr>
+          <td>${e.b.office==='huashan'?'華山辦公室':'三重辦公室'}</td>
+          <td>${e.b.room}</td><td>${e.b.date}</td><td>${e.b.startTime}</td><td>${e.b.endTime}</td><td>${e.b.subject}</td><td>${e.b.organizer}</td>
+          <td><button class="del-btn" data-type="past" data-idx="${e.i}">刪除</button></td>
+        </tr>`).join(''); }
+      document.querySelectorAll('.del-btn').forEach(btn=>btn.addEventListener('click',()=>{
+        if(!confirm('確定刪除？')) return;
+        const idx=+btn.dataset.idx;
+        if(btn.dataset.type==='upcoming'){ const list=loadBookings(); list.splice(idx,1); saveBookings(list); }
+        else { const list=loadPast(); list.splice(idx,1); savePast(list); }
+        renderTables();
+      })); }
 
     // 表單事件
     const form=document.getElementById('bookingForm'), err=document.getElementById('errorMsg');
@@ -166,9 +198,14 @@
       if(end<=start){ err.textContent='結束時間需晚於開始時間。'; return; }
       const nb={office,room,date,startTime:start,endTime:end,subject,organizer:org}, bs=loadBookings();
       if(hasConflict(bs,nb)){ err.textContent='此時段已被預約，請選其他時間或會議室。'; return; }
-      bs.push(nb); saveBookings(bs); renderTable(); form.reset();
+      bs.push(nb); saveBookings(bs);
+      const keepOffice=form.office.value;
+      renderTables();
+      form.reset();
+      form.office.value=keepOffice;
     });
-    document.getElementById('resetBtn').addEventListener('click',()=>{ form.reset(); err.textContent=''; });
+    document.getElementById('resetBtn').addEventListener('click',()=>{ form.reset(); err.textContent=''; renderTables(); });
+    document.getElementById('office').addEventListener('change',renderTables);
 
     // 日期／時間選擇器共用
     const calOverlay=document.getElementById('calOverlay'), grid=document.getElementById('calGrid'), titleEl=document.getElementById('calTitle'), prevBtn=document.getElementById('calPrev'), nextBtn=document.getElementById('calNext');
@@ -212,7 +249,7 @@
       const d=new Date(); d.setHours(hh); d.setMinutes(mm+mins);
       document.getElementById('endTime').value=`${String(d.getHours()).padStart(2,'0')}:${String(d.getMinutes()).padStart(2,'0')}`;
     }));
-    renderTable();
+    renderTables();
   })();
   </script>
 </body>


### PR DESCRIPTION
## Summary
- filter and split bookings by office selection
- allow deleting meetings with confirmation and archive past ones
- add 90- and 120-minute quick duration buttons

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689168707afc8320a07b57a6d8035798